### PR TITLE
Escape quotes in video description

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -268,12 +268,21 @@
     }
 
     function getData() {
-      return $input.val();
+      var val = $input.val();
+
+      var unescaped = val.split(String.fromCharCode(92,92)).join(String.fromCharCode(92));
+      return unescaped;
     }
 
     function setData(data) {
       var str = JSON.stringify(data);
-      $input.val(str);
+      if(!str) {
+        $input.val('');
+        return;
+      }
+
+      var escaped = str.split(String.fromCharCode(92)).join(String.fromCharCode(92,92));
+      $input.val(escaped);
     }
   }
 


### PR DESCRIPTION
Videos with double quotes in the description were failing to output the JSON correctly.