### PR TITLE
Fixed field when used in WP Block Editor (Gutenberg)

### DIFF
--- a/acf-vimeo-pro-data.php
+++ b/acf-vimeo-pro-data.php
@@ -4,7 +4,7 @@
 Plugin Name: Advanced Custom Fields: Vimeo Pro Data
 Plugin URI: https://github.com/ttillberg/acf-vimeo-pro-data
 Description: Retrieves video sources from Vimeo Pro account
-Version: 1.1.5
+Version: 1.1.6
 Author: Theo Tillberg
 Author URI: theoberg.com
 License: GPLv2 or later

--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -273,24 +273,26 @@
 
     function setData(data) {
       var str = JSON.stringify(data);
-      $input.val(str);
+      $input.val(str).change();
+
+      
     }
   }
 
   if (typeof acf.add_action !== "undefined") {
     /*
-		*  ready append (ACF5)
-		*
-		*  These are 2 events which are fired during the page load
-		*  ready = on page load similar to $(document).ready()
-		*  append = on new DOM elements appended via repeater field
-		*
-		*  @type	event
-		*  @date	20/07/13
-		*
-		*  @param	$el (jQuery selection) the jQuery element which contains the ACF fields
-		*  @return	n/a
-		*/
+    *  ready append (ACF5)
+    *
+    *  These are 2 events which are fired during the page load
+    *  ready = on page load similar to $(document).ready()
+    *  append = on new DOM elements appended via repeater field
+    *
+    *  @type  event
+    *  @date  20/07/13
+    *
+    *  @param $el (jQuery selection) the jQuery element which contains the ACF fields
+    *  @return  n/a
+    */
 
     acf.add_action("ready append", function($el) {
       // search $el for fields of type 'vimeo_pro_data'
@@ -300,19 +302,19 @@
     });
   } else {
     /*
-		*  acf/setup_fields (ACF4)
-		*
-		*  This event is triggered when ACF adds any new elements to the DOM.
-		*
-		*  @type	function
-		*  @since	1.0.0
-		*  @date	01/01/12
-		*
-		*  @param	event		e: an event object. This can be ignored
-		*  @param	Element		postbox: An element which contains the new HTML
-		*
-		*  @return	n/a
-		*/
+    *  acf/setup_fields (ACF4)
+    *
+    *  This event is triggered when ACF adds any new elements to the DOM.
+    *
+    *  @type  function
+    *  @since 1.0.0
+    *  @date  01/01/12
+    *
+    *  @param event   e: an event object. This can be ignored
+    *  @param Element   postbox: An element which contains the new HTML
+    *
+    *  @return  n/a
+    */
 
     $(document).on("acf/setup_fields", function(e, postbox) {
       $(postbox)

--- a/fields/acf-vimeo_pro_data-v5.php
+++ b/fields/acf-vimeo_pro_data-v5.php
@@ -1,33 +1,26 @@
 <?php
 
-// exit if accessed directly
-if (! defined('ABSPATH')) {
-    exit;
-}
-
 
 // check if class already exists
 if (!class_exists('acf_field_vimeo_pro_data')) :
 
 
-class acf_field_vimeo_pro_data extends acf_field
-{
-
+class acf_field_vimeo_pro_data extends acf_field {
 
     /*
-    *  __construct
+    *  initialize
     *
     *  This function will setup the field type data
     *
-    *  @type	function
-    *  @date	5/03/2014
-    *  @since	5.0.0
+    *  @type    function
+    *  @date    5/03/2014
+    *  @since   5.0.0
     *
-    *  @param	n/a
-    *  @return	n/a
+    *  @param   n/a
+    *  @return  n/a
     */
 
-    public function __construct($settings)
+    function initialize()
     {
 
         /*
@@ -55,9 +48,8 @@ class acf_field_vimeo_pro_data extends acf_field
         *  defaults (array) Array of default settings which are merged into the field object. These are used later in settings
         */
 
-        // $this->defaults = array(
-        //     'font_size'	=> 14,
-        // );
+        $this->defaults = array(
+        );
 
 
         /*
@@ -66,7 +58,7 @@ class acf_field_vimeo_pro_data extends acf_field
         */
 
         $this->l10n = array(
-            'error'	=> __('Error! Please enter a higher value', 'acf-vimeo_pro_data'),
+            'error' => __('Error! Please enter a higher value', 'acf-vimeo_pro_data'),
         );
 
 
@@ -74,40 +66,9 @@ class acf_field_vimeo_pro_data extends acf_field
         *  settings (array) Store plugin settings (url, path, version) as a reference for later use with assets
         */
 
-        $this->settings = $settings;
 
-
-        // do not delete!
-        parent::__construct();
     }
 
-
-    /*
-    *  render_field_settings()
-    *
-    *  Create extra settings for your field. These are visible when editing a field
-    *
-    *  @type	action
-    *  @since	3.6
-    *  @date	23/01/13
-    *
-    *  @param	$field (array) the $field being edited
-    *  @return	n/a
-    */
-
-    public function render_field_settings($field)
-    {
-
-        /*
-        *  acf_render_field_setting
-        *
-        *  This function will create a setting for your field. Simply pass the $field parameter and an array of field settings.
-        *  The array of settings does not require a `value` or `prefix`; These settings are found from the $field array.
-        *
-        *  More than one setting can be added by copy/paste the above code.
-        *  Please note that you must also have a matching $defaults value for the field name (font_size)
-        */ 
-    }
 
 
 
@@ -116,53 +77,45 @@ class acf_field_vimeo_pro_data extends acf_field
     *
     *  Create the HTML interface for your field
     *
-    *  @param	$field (array) the $field being rendered
+    *  @param   $field (array) the $field being rendered
     *
-    *  @type	action
-    *  @since	3.6
-    *  @date	23/01/13
+    *  @type    action
+    *  @since   3.6
+    *  @date    23/01/13
     *
-    *  @param	$field (array) the $field being edited
-    *  @return	n/a
+    *  @param   $field (array) the $field being edited
+    *  @return  n/a
     */
 
-    public function render_field($field)
-    {
-
+    function render_field($field) {
 
         /*
         *  Review the data of $field.
         *  This will show what data is available
         */
 
-        // echo '<pre>';
-            // print_r( $field );
-        // echo '</pre>';
 
-
-        /*
-        *  Create a simple text input using the 'font_size' setting.
-        */
 
         ?>
-		<div class="acf-vimeo-pro-data">
-			<div class="ui search">
-				<input class="prompt" type="text" placeholder="Look up title..." autocomplete="on">
-				<div class="results"></div>
-			</div>
-			<input type="hidden" placeholder="VIMEO ID" class="acf-vimeo-pro-data-input" />
-			<div class="acf-vimeo-pro-data-display"></div>
-			<div class="acf-vimeo-pro-data__buttons">
-				<a class="button button-secondary button-small acf-vimeo-pro-data__refresh " href="javascript:void(0);">Refresh</a>&nbsp;
-				<a class="button button-secondary button-small acf-vimeo-pro-data__clear" href="javascript:void(0);">Clear</a>
-			</div>
-			<input type="hidden" class="acf-vimeo-pro-data__hidden-input" name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($field['value']) ?>" />
-			<div class="acf-vimeo-pro-data__message"></div>
-		</div>
-		<?php
+        <div class="acf-vimeo-pro-data">
+            <div class="ui search">
+                <input class="prompt" type="text" placeholder="Look up title..." autocomplete="on">
+                <div class="results"></div>
+            </div>
+            <input type="hidden" placeholder="VIMEO ID" class="acf-vimeo-pro-data-input" />
+            <div class="acf-vimeo-pro-data-display"></div>
+            <div class="acf-vimeo-pro-data__buttons">
+                <a class="button button-secondary button-small acf-vimeo-pro-data__refresh " href="javascript:void(0);">Refresh</a>&nbsp;
+                <a class="button button-secondary button-small acf-vimeo-pro-data__clear" href="javascript:void(0);">Clear</a>
+            </div>
+            <input type="hidden" class="acf-vimeo-pro-data__hidden-input" name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($field['value']) ?>" />
+
+            <div class="acf-vimeo-pro-data__message"></div>
+        </div>
+        <?php
     }
 
-    public function getVimeoToken()
+    function getVimeoToken()
     {
         return get_field('acf_vimeo_auth_token', 'options');
     }
@@ -174,20 +127,21 @@ class acf_field_vimeo_pro_data extends acf_field
     *  This action is called in the admin_enqueue_scripts action on the edit screen where your field is created.
     *  Use this action to add CSS + JavaScript to assist your render_field() action.
     *
-    *  @type	action (admin_enqueue_scripts)
-    *  @since	3.6
-    *  @date	23/01/13
+    *  @type    action (admin_enqueue_scripts)
+    *  @since   3.6
+    *  @date    23/01/13
     *
-    *  @param	n/a
-    *  @return	n/a
+    *  @param   n/a
+    *  @return  n/a
     */
 
-    public function input_admin_enqueue_scripts()
+    function input_admin_enqueue_scripts()
     {
-
+                
         // vars
-        $url = $this->settings['url'];
-        $version = $this->settings['version'];
+
+        $url = plugin_dir_url( __DIR__ );
+        $version = acf_get_setting('version');
 
         // register search plugin
         wp_register_script('acf-input-vimeo_pro_data--ui-search', "{$url}assets/search/search.js");
@@ -213,128 +167,6 @@ class acf_field_vimeo_pro_data extends acf_field
 
 
 
-    /*
-    *  input_admin_head()
-    *
-    *  This action is called in the admin_head action on the edit screen where your field is created.
-    *  Use this action to add CSS and JavaScript to assist your render_field() action.
-    *
-    *  @type	action (admin_head)
-    *  @since	3.6
-    *  @date	23/01/13
-    *
-    *  @param	n/a
-    *  @return	n/a
-    */
-
-    /*
-
-    function input_admin_head() {
-
-
-
-    }
-
-    */
-
-
-    /*
-    *  input_form_data()
-    *
-    *  This function is called once on the 'input' page between the head and footer
-    *  There are 2 situations where ACF did not load during the 'acf/input_admin_enqueue_scripts' and
-    *  'acf/input_admin_head' actions because ACF did not know it was going to be used. These situations are
-    *  seen on comments / user edit forms on the front end. This function will always be called, and includes
-    *  $args that related to the current screen such as $args['post_id']
-    *
-    *  @type	function
-    *  @date	6/03/2014
-    *  @since	5.0.0
-    *
-    *  @param	$args (array)
-    *  @return	n/a
-    */
-
-    /*
-
-    function input_form_data( $args ) {
-
-
-
-    }
-
-    */
-
-
-    /*
-    *  input_admin_footer()
-    *
-    *  This action is called in the admin_footer action on the edit screen where your field is created.
-    *  Use this action to add CSS and JavaScript to assist your render_field() action.
-    *
-    *  @type	action (admin_footer)
-    *  @since	3.6
-    *  @date	23/01/13
-    *
-    *  @param	n/a
-    *  @return	n/a
-    */
-
-    /*
-
-    function input_admin_footer() {
-
-
-
-    }
-
-    */
-
-
-    /*
-    *  field_group_admin_enqueue_scripts()
-    *
-    *  This action is called in the admin_enqueue_scripts action on the edit screen where your field is edited.
-    *  Use this action to add CSS + JavaScript to assist your render_field_options() action.
-    *
-    *  @type	action (admin_enqueue_scripts)
-    *  @since	3.6
-    *  @date	23/01/13
-    *
-    *  @param	n/a
-    *  @return	n/a
-    */
-
-    /*
-
-    function field_group_admin_enqueue_scripts() {
-
-    }
-
-    */
-
-
-    /*
-    *  field_group_admin_head()
-    *
-    *  This action is called in the admin_head action on the edit screen where your field is edited.
-    *  Use this action to add CSS and JavaScript to assist your render_field_options() action.
-    *
-    *  @type	action (admin_head)
-    *  @since	3.6
-    *  @date	23/01/13
-    *
-    *  @param	n/a
-    *  @return	n/a
-    */
-
-    /*
-
-    function field_group_admin_head() {
-
-    }
-
-    */
 
 
     /*
@@ -342,19 +174,19 @@ class acf_field_vimeo_pro_data extends acf_field
     *
     *  This filter is applied to the $value after it is loaded from the db
     *
-    *  @type	filter
-    *  @since	3.6
-    *  @date	23/01/13
+    *  @type    filter
+    *  @since   3.6
+    *  @date    23/01/13
     *
-    *  @param	$value (mixed) the value found in the database
-    *  @param	$post_id (mixed) the $post_id from which the value was loaded
-    *  @param	$field (array) the field array holding all the field options
-    *  @return	$value
+    *  @param   $value (mixed) the value found in the database
+    *  @param   $post_id (mixed) the $post_id from which the value was loaded
+    *  @param   $field (array) the field array holding all the field options
+    *  @return  $value
     */
 
 
 
-    public function load_value($value, $post_id, $field)
+    function load_value($value, $post_id, $field)
     {
         return $value;
     }
@@ -366,20 +198,21 @@ class acf_field_vimeo_pro_data extends acf_field
     *
     *  This filter is applied to the $value before it is saved in the db
     *
-    *  @type	filter
-    *  @since	3.6
-    *  @date	23/01/13
+    *  @type    filter
+    *  @since   3.6
+    *  @date    23/01/13
     *
-    *  @param	$value (mixed) the value found in the database
-    *  @param	$post_id (mixed) the $post_id from which the value was loaded
-    *  @param	$field (array) the field array holding all the field options
-    *  @return	$value
+    *  @param   $value (mixed) the value found in the database
+    *  @param   $post_id (mixed) the $post_id from which the value was loaded
+    *  @param   $field (array) the field array holding all the field options
+    *  @return  $value
     */
 
 
-    public function update_value($value, $post_id, $field)
+    function update_value($value, $post_id, $field)
     {
         return $value;
+                
     }
 
 
@@ -389,20 +222,20 @@ class acf_field_vimeo_pro_data extends acf_field
     *
     *  This filter is appied to the $value after it is loaded from the db and before it is returned to the template
     *
-    *  @type	filter
-    *  @since	3.6
-    *  @date	23/01/13
+    *  @type    filter
+    *  @since   3.6
+    *  @date    23/01/13
     *
-    *  @param	$value (mixed) the value which was loaded from the database
-    *  @param	$post_id (mixed) the $post_id from which the value was loaded
-    *  @param	$field (array) the field array holding all the field options
+    *  @param   $value (mixed) the value which was loaded from the database
+    *  @param   $post_id (mixed) the $post_id from which the value was loaded
+    *  @param   $field (array) the field array holding all the field options
     *
-    *  @return	$value (mixed) the modified value
+    *  @return  $value (mixed) the modified value
     */
 
 
 
-    public function format_value($value, $post_id, $field)
+    function format_value($value, $post_id, $field)
     {
 
         // bail early if no value
@@ -416,151 +249,13 @@ class acf_field_vimeo_pro_data extends acf_field
     }
 
 
-
-
-    /*
-    *  validate_value()
-    *
-    *  This filter is used to perform validation on the value prior to saving.
-    *  All values are validated regardless of the field's required setting. This allows you to validate and return
-    *  messages to the user if the value is not correct
-    *
-    *  @type	filter
-    *  @date	11/02/2014
-    *  @since	5.0.0
-    *
-    *  @param	$valid (boolean) validation status based on the value and the field's required setting
-    *  @param	$value (mixed) the $_POST value
-    *  @param	$field (array) the field array holding all the field options
-    *  @param	$input (string) the corresponding input name for $_POST value
-    *  @return	$valid
-    */
-
-    /*
-
-    function validate_value( $valid, $value, $field, $input ){
-
-        // Basic usage
-        if( $value < $field['custom_minimum_setting'] )
-        {
-            $valid = false;
-        }
-
-
-        // Advanced usage
-        if( $value < $field['custom_minimum_setting'] )
-        {
-            $valid = __('The value is too little!','acf-vimeo_pro_data'),
-        }
-
-
-        // return
-        return $valid;
-
-    }
-
-    */
-
-
-    /*
-    *  delete_value()
-    *
-    *  This action is fired after a value has been deleted from the db.
-    *  Please note that saving a blank value is treated as an update, not a delete
-    *
-    *  @type	action
-    *  @date	6/03/2014
-    *  @since	5.0.0
-    *
-    *  @param	$post_id (mixed) the $post_id from which the value was deleted
-    *  @param	$key (string) the $meta_key which the value was deleted
-    *  @return	n/a
-    */
-
-
-
-    public function delete_value($post_id, $key)
-    {
-    }
-
-
-
-
-    /*
-    *  load_field()
-    *
-    *  This filter is applied to the $field after it is loaded from the database
-    *
-    *  @type	filter
-    *  @date	23/01/2013
-    *  @since	3.6.0
-    *
-    *  @param	$field (array) the field array holding all the field options
-    *  @return	$field
-    */
-
-    /*
-
-    function load_field( $field ) {
-
-        return $field;
-
-    }
-
-    */
-
-
-    /*
-    *  update_field()
-    *
-    *  This filter is applied to the $field before it is saved to the database
-    *
-    *  @type	filter
-    *  @date	23/01/2013
-    *  @since	3.6.0
-    *
-    *  @param	$field (array) the field array holding all the field options
-    *  @return	$field
-    */
-
-    /*
-
-    function update_field( $field ) {
-
-        return $field;
-
-    }
-
-    */
-
-
-    /*
-    *  delete_field()
-    *
-    *  This action is fired after a field is deleted from the database
-    *
-    *  @type	action
-    *  @date	11/02/2014
-    *  @since	5.0.0
-    *
-    *  @param	$field (array) the field array holding all the field options
-    *  @return	n/a
-    */
-
-    /*
-
-    function delete_field( $field ) {
-
-
-
-    }
-
-    */
 }
 
 
+
+
 // initialize
-new acf_field_vimeo_pro_data($this->settings);
+acf_register_field_type( 'acf_field_vimeo_pro_data' );
 
 
 // class_exists check


### PR DESCRIPTION
Updated php class to extend acf_field and fixed js error where field wasn't saving data when use in WP Block Editor.