### PR TITLE
fixed the actual root of #32

### DIFF
--- a/admin-settings.php
+++ b/admin-settings.php
@@ -9,7 +9,7 @@ function plugin_add_settings_link($links)
 }
 
 $initSettings = function () {
-    if (!current_user_can('administrator') || !function_exists('acf_add_options_page') || !function_exists('acf_add_local_field_group')) {
+    if (!function_exists('acf_add_options_page') || !function_exists('acf_add_local_field_group')) {
         return;
     }
     add_filter("plugin_action_links_acf-vimeo-pro-data/acf-vimeo-pro-data.php", 'plugin_add_settings_link');

--- a/fields/acf-vimeo_pro_data-v5.php
+++ b/fields/acf-vimeo_pro_data-v5.php
@@ -117,7 +117,7 @@ class acf_field_vimeo_pro_data extends acf_field {
 
     function getVimeoToken()
     {
-        return get_option('options_acf_vimeo_auth_token');
+        return get_field('acf_vimeo_auth_token', 'options');
     }
 
 


### PR DESCRIPTION
Turns out #32  was caused by having a capability check in the function that registered the field,  so the field is not registered for non-admin users:

https://github.com/ttillberg/acf-vimeo-pro-data/blob/6ed6769c472bbecacdcbcbdd2c4dbcca7e320403/admin-settings.php#L12

I think it's not necessary there and could rather be tackled in the `capabilites` field of `acf_add_options_sub_page()`.

Got the hint in
https://support.advancedcustomfields.com/forums/topic/get_field-field-option-return-null-for-non-admin-users/#post-150078

Works fine in my tests.